### PR TITLE
Add option to import suspended users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Define the following environment variables:
 OIDC_AGENT_ALIAS=<your-client-alias>
 OIDC_AGENT_SECRET=<your-client-secret>
 IAM_ENDPOINT=iam-dev.cloud.cnaf.infn.it
-IAM_HOST=https://iam-dev.cloud.cnaf.infn.it
 VOMS_HOST=meteora.cloud.cnaf.infn.it
 VOMS_VO=test.vo
 X509_USER_PROXY=/tmp/x509up_u1000
@@ -46,5 +45,5 @@ $ ./docker/init-credentials.sh
 Run the importer with
 
 ```
-python vomsimporter.py --vo ${VOMS_VO} --voms-host ${VOMS_HOST} --iam-host ${IAM_HOST} --skip-duplicate-accounts-checks --username-attr nickname --debug --voms-port 8443
+python vomsimporter.py --vo ${VOMS_VO} --voms-host ${VOMS_HOST} --iam-host ${IAM_ENDPOINT} --skip-duplicate-accounts-checks --username-attr nickname --debug --voms-port 8443
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Define the following environment variables:
 ```
 OIDC_AGENT_ALIAS=<your-client-alias>
 OIDC_AGENT_SECRET=<your-client-secret>
-IAM_ENDPOINT=iam-dev.cloud.cnaf.infn.it
+IAM_ENDPOINT=https://iam-dev.cloud.cnaf.infn.it
+IAM_HOST=iam-dev.cloud.cnaf.infn.it
 VOMS_HOST=meteora.cloud.cnaf.infn.it
 VOMS_VO=test.vo
 X509_USER_PROXY=/tmp/x509up_u1000
@@ -45,5 +46,5 @@ $ ./docker/init-credentials.sh
 Run the importer with
 
 ```
-python vomsimporter.py --vo ${VOMS_VO} --voms-host ${VOMS_HOST} --iam-host ${IAM_ENDPOINT} --skip-duplicate-accounts-checks --username-attr nickname --debug --voms-port 8443
+python vomsimporter.py --vo ${VOMS_VO} --voms-host ${VOMS_HOST} --iam-host ${IAM_HOST} --skip-duplicate-accounts-checks --username-attr nickname --debug --voms-port 8443
 ```

--- a/docker/init-credentials.sh
+++ b/docker/init-credentials.sh
@@ -33,7 +33,7 @@ chmod 600 ${proxyresponse}
 
 set +e
 
-curl -s -XPOST -H "Authorization: Bearer ${BT}" \
+curl -s -L -XPOST -H "Authorization: Bearer ${BT}" \
         -d client_id=${client_id} \
         -d client_secret=${client_secret} \
         -d lifetimeSecs=${PROXY_CERT_LIFETIME_SECS} \

--- a/docker/init-credentials.sh
+++ b/docker/init-credentials.sh
@@ -33,7 +33,7 @@ chmod 600 ${proxyresponse}
 
 set +e
 
-curl -s -L -XPOST -H "Authorization: Bearer ${BT}" \
+curl -s -XPOST -H "Authorization: Bearer ${BT}" \
         -d client_id=${client_id} \
         -d client_secret=${client_secret} \
         -d lifetimeSecs=${PROXY_CERT_LIFETIME_SECS} \

--- a/vomsimporter.py
+++ b/vomsimporter.py
@@ -603,8 +603,11 @@ class IamService:
             logging.info("Importing certificate %s for user %s" %
                          (c, iam_user_str))
             if c['suspended']:
-                logging.info('Skipping certificate %s as is suspended' % c)
-                continue
+                if self._import_suspended_users:
+                    logging.info("Importing suspended certificate %s", c)
+                else:
+                    logging.info('Skipping certificate %s as is suspended' % c)
+                    continue
 
             try:
                 converted_subject = convert_dn_rfc2253(c['subjectString'])

--- a/vomsimporter.py
+++ b/vomsimporter.py
@@ -374,7 +374,7 @@ class IamService:
                 logging.error("Error linking certificate: %s to account %s: %s",
                               cert, iam_user['id'], e.response.status_code)
 
-    def synchronise_aup(self, iam_user, voms_user):
+    def synchronize_aup(self, iam_user, voms_user):
         url = "%s/iam/aup/signature/%s" % (self._base_url(), iam_user['id'])
         headers = self._build_authz_header()
         headers['Content-type'] = "application/json"
@@ -386,10 +386,10 @@ class IamService:
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
             if e.response is None:
-                logging.error("Failed AUP synchronisation for account %s: %s",
+                logging.error("Failed AUP synchronization for account %s: %s",
                             iam_user['id'], e)
             else:
-                logging.error("Failed AUP synchronisation for account %s with error: %s",
+                logging.error("Failed AUP synchronization for account %s with error: %s",
                             iam_user['id'], e.response.content)
 
     def synchronize_activation(self, iam_user, voms_user):
@@ -576,7 +576,7 @@ class IamService:
             iam_user = self.create_user_from_voms(voms_user)
             new_user = True
 
-        self.synchronise_aup(iam_user, voms_user)
+        self.synchronize_aup(iam_user, voms_user)
         if self._synchronize_activation_status and iam_user['active'] == voms_user['suspended']:
             self.synchronize_activation(iam_user, voms_user)
 

--- a/vomsimporter.py
+++ b/vomsimporter.py
@@ -327,7 +327,8 @@ class IamService:
                 "value": voms_user['emailAddress'],
                 "type": "work",
                 "primary": True
-            }]
+            }],
+            "endTime": voms_user.get('endTime')
         }
 
         r = self._s.post(url, headers=headers, json=payload)


### PR DESCRIPTION
This commit fixes #21 

- When the flag `--import-suspended-users` is passed it also imports the users that are suspended on VOMS-Admin
- When it's not passed the behavior is the same as before
- When creating a user on IAM, instead of directly making it not suspended, it checks if the user is suspended on VOMS-Admin

I tested it on our wlcg-auth-dev instance and it looks like it's working as expected but it would be great if you double-check.